### PR TITLE
Exclude Mapping Columns if they are defined as computed columns in the database schema

### DIFF
--- a/JSqlServerBulkInsert/pom.xml
+++ b/JSqlServerBulkInsert/pom.xml
@@ -63,7 +63,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sqlserver.version>12.4.1.jre11</sqlserver.version>
+        <sqlserver.version>12.6.1.jre11</sqlserver.version>
     </properties>
 
 

--- a/JSqlServerBulkInsert/src/main/java/de/bytefish/jsqlserverbulkinsert/util/SchemaUtils.java
+++ b/JSqlServerBulkInsert/src/main/java/de/bytefish/jsqlserverbulkinsert/util/SchemaUtils.java
@@ -23,12 +23,14 @@ public class SchemaUtils {
         List<SchemaMetaData.ColumnInformation> columnInformations = new ArrayList<>();
 
         while (rs.next()) {
-            SchemaMetaData.ColumnInformation columnInformation = new SchemaMetaData.ColumnInformation(
-                    rs.getString("COLUMN_NAME"),
-                    rs.getInt("ORDINAL_POSITION")
-            );
+            if(rs.getString("IS_GENERATEDCOLUMN").equals("NO")) {
+                SchemaMetaData.ColumnInformation columnInformation = new SchemaMetaData.ColumnInformation(
+                        rs.getString("COLUMN_NAME"),
+                        rs.getInt("ORDINAL_POSITION")
+                );
 
-            columnInformations.add(columnInformation);
+                columnInformations.add(columnInformation);
+            }
         }
 
         // Make sure they are sorted ascending by Ordinals:

--- a/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/integration/IntegrationTest.java
+++ b/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/integration/IntegrationTest.java
@@ -65,7 +65,8 @@ public class IntegrationTest extends TransactionalTestBase {
                 "            (\n" +
                 "                FirstName NVARCHAR(255),\n" +
                 "                LastName NVARCHAR(255),\n" +
-                "                BirthDate DATE\n" +
+                "                BirthDate DATE,\n" +
+                "                Retirement AS (dateadd(year,(60),BirthDate)) \n" +
                 "            );";
 
         Statement statement = connection.createStatement();

--- a/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/model/Person.java
+++ b/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/model/Person.java
@@ -13,6 +13,8 @@ public class Person {
 
     private LocalDate birthDate;
 
+    private LocalDate retiringDate;
+
     public Person() {
     }
 
@@ -38,5 +40,13 @@ public class Person {
 
     public void setBirthDate(LocalDate birthDate) {
         this.birthDate = birthDate;
+    }
+
+    public LocalDate getRetiringDate() {
+        return retiringDate;
+    }
+
+    public void setRetiringDate(LocalDate retiringDate) {
+        this.retiringDate = retiringDate;
     }
 }


### PR DESCRIPTION
Updated mssql-jdbc to 12.6.1.jre11.
Fix for excluding computed columns in the column mapping collection.